### PR TITLE
Update the MkDocs pages configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: CentOS Docs
 pages:
-- ['index.md', 'Home']
-- ['docker.md', 'Docs', 'Docker']
-- ['about.md', 'About']
+- Home: 'index.md'
+- Docs:
+  - Docker: 'docker.md'
+- About: 'about.md'
 
 theme : readthedocs


### PR DESCRIPTION
In MkDocs [0.13.0](http://www.mkdocs.org/about/release-notes/#change-the-pages-configuration) and above, there is a new, better way to define the
pages confirguration. It will be used in future MkDocs releases and the
current method is deprecated and will be removed in 1.0.
